### PR TITLE
chore(http): bootstrap Dio client w/ withCredentials (web) and env-based API_BASE_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,29 @@
 # Flutter/Dart
 .dart_tool/
 .packages
+.flutter-plugins
+.flutter-plugins-dependencies
 build/
 
 # Platform
 ios/Pods/
 android/.gradle/
 android/local.properties
+# (추가 플랫폼 생기면 필요 시 무시 규칙 추가)
 
 # IDE
 .vscode/
 .idea/
 
-.flutter-plugins
-.flutter-plugins-dependencies
+# Monorepo tool (미사용이면 그냥 둬도 무방)
 .melos_tool
-.dart_tool/
-.packages
-firebase_app_id_file.json
+
+# Flutter metadata(보통 무시)
 .metadata
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Firebase
+# firebase_app_id_file.json   # Firebase 사용할 계획이면 주석 처리(즉, 커밋)

--- a/lib/core/env/env.dart
+++ b/lib/core/env/env.dart
@@ -1,0 +1,6 @@
+class Env {
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://localhost:8080',
+  );
+}

--- a/lib/core/http/api_client.dart
+++ b/lib/core/http/api_client.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+
+import '../env/env.dart';
+import 'with_credentials_io.dart'
+    if (dart.library.html) 'with_credentials_web.dart';
+
+Dio createDio() {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: Env.apiBaseUrl,
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+      contentType: 'application/json',
+      headers: const {'Accept': 'application/json'},
+    ),
+  );
+
+  // 웹에서 쿠키(리프레시 토큰) 포함되도록 설정
+  configureWithCredentials(dio);
+
+  return dio;
+}
+
+final Dio http = createDio();

--- a/lib/core/http/with_credentials_io.dart
+++ b/lib/core/http/with_credentials_io.dart
@@ -1,0 +1,3 @@
+import 'package:dio/dio.dart';
+
+void configureWithCredentials(Dio dio) {}

--- a/lib/core/http/with_credentials_web.dart
+++ b/lib/core/http/with_credentials_web.dart
@@ -1,0 +1,6 @@
+import 'package:dio/dio.dart';
+import 'package:dio/browser.dart';
+
+void configureWithCredentials(Dio dio) {
+  dio.httpClientAdapter = BrowserHttpClientAdapter()..withCredentials = true;
+}


### PR DESCRIPTION
## 요약
- FE에서 BE 인증 흐름(리프레시 토큰 HttpOnly 쿠키)을 지원하기 위해 Dio 클라이언트 기본 설정을 추가
- 웹 환경에서 `withCredentials=true` 설정으로 `Set-Cookie`/쿠키 왕복 가능
- 런타임에 `--dart-define=API_BASE_URL=...` 로 API 베이스 경로를 주입

## 변경 사항
- lib/env/env.dart: `Env.apiBaseUrl` (String.fromEnvironment)
- lib/core/http.dart: 공용 Dio 인스턴스 생성(타임아웃/헤더/컨텐츠타입)
- lib/core/with_credentials_io.dart / web.dart: 플랫폼별 withCredentials 분기
- pubspec.yaml: dio 의존성 추가

## 체크리스트
- [x] `flutter analyze` 무경고
- [x] `flutter test` 통과 (테스트 없음 → 통과)
- [x] (웹) `flutter run -d chrome --web-port 5173 --dart-define=API_BASE_URL=http://localhost:8080` 로 구동 확인

## 검증 방법
1) 백엔드(dev) 구동 및 CORS 설정 활성화(OPTIONS 허용, Allow-Credentials, Expose: Set-Cookie).
2) 프런트 구동: flutter run -d chrome –web-port 5173 
–dart-define=API_BASE_URL=http://localhost:8080