### PR TITLE
feat(auth/web): add logout functionality (access tokoken/storage init…

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,18 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:route_pick_fe/app/router.dart';
+import 'package:route_pick_fe/features/state/auth_providers.dart';
 
 class App extends ConsumerWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.watch(routerProvider);
-    return MaterialApp.router(
-      title: 'RoutePick',
-      routerConfig: router,
-      theme: ThemeData(colorSchemeSeed: Colors.teal, useMaterial3: true),
-      debugShowCheckedModeBanner: false,
+    final boot = ref.watch(bootProvider);
+    return boot.when(
+      loading: () => const _Splash(),
+      error: (_, __) => const _Splash(error: true),
+      data: (_) {
+        final router = ref.watch(routerProvider);
+        return MaterialApp.router(
+          routerConfig: router,
+          title: 'RoutePick',
+          theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.indigo),
+        );
+      },
+    );
+  }
+}
+
+class _Splash extends StatelessWidget {
+  const _Splash({this.error = false});
+  final bool error;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: error
+              ? const Text('초기화 실패. 다시 실행해 주세요.')
+              : const CircularProgressIndicator(),
+        ),
+      ),
     );
   }
 }

--- a/lib/core/http/api_client.dart
+++ b/lib/core/http/api_client.dart
@@ -1,23 +1,21 @@
-import 'package:dio/browser.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:route_pick_fe/core/env/env.dart';
 
-final Dio http = (() {
-  final dio = Dio(
-    BaseOptions(
-      baseUrl: Env.apiBaseUrl,
-      connectTimeout: const Duration(seconds: 10),
-      receiveTimeout: const Duration(seconds: 10),
-      contentType: 'application/json',
-      headers: const {'Accept': 'application/json'},
-    ),
-  );
+// 웹/비웹에 따라 다른 구현을 선택적으로 불러온다.
+import 'with_credentials_io.dart'
+    if (dart.library.html) 'with_credentials_web.dart';
 
-  // 웹에서 리프레시 쿠키를 오가게 하려면 withCredentials: true 필요
-  if (kIsWeb) {
-    dio.httpClientAdapter = BrowserHttpClientAdapter()..withCredentials;
-  }
+// 앱 전역에서 쓰는 Dio 인스턴스
+final Dio http = Dio(
+  BaseOptions(
+    baseUrl: Env.apiBaseUrl,
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 10),
+    contentType: 'application/json',
+    headers: const {'Accept': 'application/json'},
+  ),
+);
 
-  return dio;
-})();
+void initHttp() {
+  configureWithCredentials(http);
+}

--- a/lib/core/storage/token_storage.dart
+++ b/lib/core/storage/token_storage.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TokenStorage {
+  static const _key = 'accessToken';
+
+  Future<String?> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_key);
+  }
+
+  Future<void> save(String? token) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (token == null || token.isEmpty) {
+      await prefs.remove(_key);
+    } else {
+      await prefs.setString(_key, token);
+    }
+  }
+}

--- a/lib/core/web/url_strategy_stub.dart
+++ b/lib/core/web/url_strategy_stub.dart
@@ -1,0 +1,1 @@
+void setUrlStrategy() {}

--- a/lib/core/web/url_strategy_web.dart
+++ b/lib/core/web/url_strategy_web.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_web_plugins/url_strategy.dart';
+
+void setUrlStrategy() => usePathUrlStrategy();

--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -42,8 +42,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
         '[LoginPage] login OK: token len=${res.accessToken.length}, exp=${res.expiresIn}',
       );
 
-      // 토큰 저장
+      // 메모리 세팅
       ref.read(accessTokenProvider.notifier).state = res.accessToken;
+      // 디스크 저장
+      await ref.read(tokenStorageProvider).save(res.accessToken);
 
       if (!mounted) return;
 
@@ -56,7 +58,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
           ? data['message'] as String
           : '로그인에 실패했습니다: ${e.message}';
       debugPrint(
-        'LoginPage] DioException type= ${e.type}, status=${e.response?.statusCode} data=$data',
+        '[LoginPage] DioException type= ${e.type}, status=${e.response?.statusCode} data=$data',
       );
       if (mounted) {
         ScaffoldMessenger.of(

--- a/lib/features/auth/presentation/me_page.dart
+++ b/lib/features/auth/presentation/me_page.dart
@@ -24,6 +24,13 @@ class _MePageState extends ConsumerState<MePage> {
   // API 인스턴스
   final _api = AuthApi();
 
+  void _safeGo(String location) {
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) context.go(location);
+    });
+  }
+
   // 비동기: /users/me 호출
   Future<void> _loadMe() async {
     // accessToken 읽기(ref.read: 한 번 읽기)
@@ -34,6 +41,7 @@ class _MePageState extends ConsumerState<MePage> {
         _error = '로그인이 필요합니다';
         _me = null;
       });
+      _safeGo('/login?from=%2Fme');
       return;
     }
 
@@ -41,6 +49,7 @@ class _MePageState extends ConsumerState<MePage> {
       _loading = true;
       _error = null;
     });
+
     try {
       final map = await _api.me(accessToken: token);
       setState(() => _me = map);
@@ -48,7 +57,8 @@ class _MePageState extends ConsumerState<MePage> {
       // 인증 만료 --> 토큰 비우고 로그인으로
       if (e.response?.statusCode == 401) {
         ref.read(accessTokenProvider.notifier).state = null;
-        if (mounted) GoRouter.of(context).go('/login?from=%2Fme');
+        await ref.read(tokenStorageProvider).save(null);
+        _safeGo('/login?from=%2Fme');
         return;
       }
       setState(() {
@@ -61,16 +71,14 @@ class _MePageState extends ConsumerState<MePage> {
         _me = null;
       });
     } finally {
-      if (mounted) {
-        setState(() => _loading = false);
-      }
+      if (mounted) setState(() => _loading = false);
     }
   }
 
   Future<void> _logout() async {
     final token = ref.read(accessTokenProvider);
     if (token == null || token.isEmpty) {
-      if (mounted) context.go('/login');
+      _safeGo('/login');
       return;
     }
 
@@ -78,16 +86,19 @@ class _MePageState extends ConsumerState<MePage> {
     try {
       await _api.logout(accessToken: token);
     } catch (_) {
-      // 서버 요청 실패해도 클라이언트 상태는 비우기(멱등)
+      // 서버 실패여도 클라 상태는 정리 (멱등)
     } finally {
-      // 클라이언트 토큰 비우기
+      // 토큰 제거 (메모리 + 디스크)
       ref.read(accessTokenProvider.notifier).state = null;
+      await ref.read(tokenStorageProvider).save(null);
+
       if (mounted) {
         setState(() {
           _loading = false;
           _me = null;
         });
-        context.go('/login?from=%2Fme');
+        // 명시적 로그아웃이면 보통 from 없이 login으로
+        _safeGo('/login');
       }
     }
   }
@@ -106,11 +117,12 @@ class _MePageState extends ConsumerState<MePage> {
       appBar: AppBar(
         title: const Text('내 정보'),
         actions: [
-          IconButton(
-            tooltip: '로그아웃',
-            onPressed: _loading ? null : _logout, // 로딩 중이면 비활성화
-            icon: const Icon(Icons.logout),
-          ),
+          if (_me != null)
+            IconButton(
+              tooltip: '로그아웃',
+              onPressed: _loading ? null : _logout, // 로딩 중이면 비활성화
+              icon: const Icon(Icons.logout),
+            ),
         ],
       ),
       body: Center(

--- a/lib/features/state/auth_providers.dart
+++ b/lib/features/state/auth_providers.dart
@@ -1,4 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:route_pick_fe/core/storage/token_storage.dart';
 
 // 전역 인증 상태: access_token (null이면 로그아웃 상태)
 final accessTokenProvider = StateProvider<String?>((ref) => null);
+
+// DI: TokenStorage
+final tokenStorageProvider = Provider<TokenStorage>((_) => TokenStorage());
+
+// 앱 시작 시 디스크에서 토큰을 읽어와 accessTokenProvider 세팅
+final bootProvider = FutureProvider<void>((ref) async {
+  final storage = ref.read(tokenStorageProvider);
+  final token = await storage.load();
+  ref.read(accessTokenProvider.notifier).state = token;
+});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:route_pick_fe/app/app.dart';
-import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+// 전역 Dio 초기화
+import 'core/http/api_client.dart' as api_client;
+
+// 웹에서만 path 전략 사용 (비웹/테스트는 no-op)
+import 'core/web/url_strategy_stub.dart'
+    if (dart.library.html) 'core/web/url_strategy_web.dart';
 
 void main() {
-  usePathUrlStrategy();
+  setUrlStrategy(); // 웹: path, 비웹: 그대로
+  api_client.initHttp(); // 여기서 withCredentials 적용됨(웹일 때)
   runApp(const ProviderScope(child: App()));
 }

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -320,6 +328,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -344,6 +392,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -541,6 +645,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   url_strategy: ^0.3.0
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 배경
- 테스트용 간단 UI로 로그인/내정보/로그아웃 플로우 마무리.
- 웹에서 로그아웃 시 서버의 Set-Cookie(만료) 응답이 실제로 반영되도록 `withCredentials` 필요.
- VM 테스트/비웹 빌드가 웹 전용 의존성 때문에 깨지지 않도록 URL 전략을 조건부 적용.

## 변경사항
- MePage
  - `/users/me` 호출, 401시 토큰 비우고 `/login?from=/me`로 안내
  - AppBar/버튼에서 **로그아웃** 트리거
  - `_safeGo()`로 frame 이후 내비게이션(빌드 중 네비게이션 경고 회피)
  - 명시 로그아웃 시 액세스 토큰 메모리/디스크 제거 후 `/login` 이동
- LoginPage
  - 성공 시 토큰 메모리/디스크 저장
  - `from` 쿼리 있으면 거기로, 없으면 `/`
- AuthApi
  - `login`, `me`, `logout` 간단 래퍼
- 전역 Dio
  - `core/http/api_client.dart`에서 한 번만 초기화
  - `with_credentials_web.dart`: `BrowserHttpClientAdapter()..withCredentials = true`
  - `with_credentials_io.dart`: no-op
  - `initHttp()`를 통해 플랫폼별 설정 주입
- URL 전략
  - `url_strategy_web.dart`: `usePathUrlStrategy()`
  - `url_strategy_stub.dart`: no-op
  - `main.dart`에서 조건부 `setUrlStrategy()` + `initHttp()` 후 `runApp`
- 테스트
  - `@TestOn('browser')`로 웹 전용 실패 이슈 회피 (기본 위젯 스모크)

## 확인 방법
1) 웹에서 로그인 → `/me` 진입 시 내 정보 노출 확인
2) 토큰 만료(혹은 강제 401) 시 `/login?from=/me`로 이동 확인
3) **로그아웃 클릭**
   - 클라: 액세스 토큰(리버팟 상태 + 스토리지) 삭제
   - 서버 호출: `/auth/logout` 200 수신
   - DevTools Network: 요청에 `Cookie` 포함 / 응답에 `Set-Cookie`(refresh 만료) 확인
   - 라우팅: `/login`으로 이동
4) 새로고침 후도 로그인 필요 상태 유지

## 서버(CORS) 요구사항
- `Access-Control-Allow-Credentials: true`
- `Access-Control-Allow-Origin`은 구체 도메인(와일드카드 `*` 금지)
- `/auth/logout` 응답에 `Set-Cookie`(refresh=; Max-Age=0 / Expires=...) 포함

## 리스크/호환성
- 모바일/데스크톱/테스트: IO 스텁으로 영향 없음
- 네비게이션은 `_safeGo`로 빌드 타이밍 이슈 회피