### PR TITLE
feat(post): add paginated list with infinite scroll & refresh, add de…

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,6 +1,18 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:route_pick_fe/app/router.dart';
+
+class AppScrollBehavior extends MaterialScrollBehavior {
+  @override
+  Set<PointerDeviceKind> get dragDevices => {
+    PointerDeviceKind.touch,
+    PointerDeviceKind.mouse,
+    PointerDeviceKind.trackpad,
+    PointerDeviceKind.stylus,
+    PointerDeviceKind.unknown,
+  };
+}
 
 class App extends ConsumerWidget {
   const App({super.key});
@@ -12,6 +24,7 @@ class App extends ConsumerWidget {
       title: 'RoutePick',
       theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
       routerConfig: router,
+      scrollBehavior: AppScrollBehavior(),
     );
   }
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,8 @@ import 'package:go_router/go_router.dart';
 import 'package:route_pick_fe/features/auth/presentation/home_page.dart';
 import 'package:route_pick_fe/features/auth/presentation/login_page.dart';
 import 'package:route_pick_fe/features/auth/presentation/me_page.dart';
+import 'package:route_pick_fe/features/posts/presentation/post_detail_page.dart';
+import 'package:route_pick_fe/features/posts/presentation/posts_list_page.dart';
 import 'package:route_pick_fe/features/splash/presentation/splash_page.dart';
 import 'package:route_pick_fe/features/state/auth_providers.dart';
 
@@ -41,6 +43,11 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/', builder: (_, __) => const HomePage()),
       GoRoute(path: '/login', builder: (_, __) => const LoginPage()),
       GoRoute(path: '/me', builder: (_, __) => const MePage()),
+      GoRoute(path: '/posts', builder: (_, __) => const PostsListPage()),
+      GoRoute(
+        path: '/posts/:id',
+        builder: (_, state) => PostDetailPage(id: state.pathParameters['id']!),
+      ),
     ],
   );
 });

--- a/lib/features/posts/data/post_model.dart
+++ b/lib/features/posts/data/post_model.dart
@@ -1,0 +1,15 @@
+class Post {
+  final String id;
+  final String title;
+  final String? summary;
+
+  Post({required this.id, required this.title, this.summary});
+
+  factory Post.fromMap(Map<String, dynamic> m) {
+    return Post(
+      id: '${m['id']}',
+      title: (m['title'] ?? '').toString(),
+      summary: (m['summary'] ?? m['excerpt'] ?? m['content'])?.toString(),
+    );
+  }
+}

--- a/lib/features/posts/data/posts_api.dart
+++ b/lib/features/posts/data/posts_api.dart
@@ -1,0 +1,93 @@
+import 'package:dio/dio.dart';
+import 'package:route_pick_fe/core/http/api_client.dart';
+import 'package:route_pick_fe/features/posts/data/post_model.dart';
+
+class PageResult<T> {
+  final List<T> items;
+  final bool hasNext;
+  final int? nextPage;
+  const PageResult({required this.items, required this.hasNext, this.nextPage});
+}
+
+class PostsApi {
+  final Dio _dio;
+  PostsApi({Dio? dio}) : _dio = dio ?? http;
+
+  // 표준 페이지 요청 (Spring Data JPA 대응)
+  Future<PageResult<Post>> listPaged({int page = 0, int size = 20}) async {
+    final res = await _dio.get(
+      '/posts',
+      queryParameters: {
+        'page': page,
+        'size': size,
+        // 백엔드가 Spring이면 보통 createdAt(프로퍼티명), 필요 시 created_at로 맞춰주기
+        'sort': 'createdAt,desc',
+      },
+    );
+    final data = res.data;
+
+    dynamic rawList;
+    bool? last; // Spring Page의 last(boolean) 지원
+    int? totalPages; // Spring Page totalPages
+    int? number; // Spring Page number(현재 페이지 index)
+    bool? hasNextFlag; // 커스텀 API가 hasNext를 줄 수도 있음
+
+    if (data is List) {
+      rawList = data;
+    } else if (data is Map) {
+      if (data['content'] is List) {
+        rawList = data['content'];
+        last = data['last'] as bool?;
+        totalPages = (data['totalPages'] is num)
+            ? (data['totalPages'] as num).toInt()
+            : null;
+        number = (data['number'] is num)
+            ? (data['number'] as num).toInt()
+            : null;
+      } else if (data['items'] is List) {
+        rawList = data['items'];
+        if (data['hasNext'] is bool) hasNextFlag = data['hasNext'] as bool;
+      } else if (data['data'] is Map) {
+        final inner = data['data'] as Map;
+        if (inner['items'] is List) {
+          rawList = inner['items'];
+          if (inner['hasNext'] is bool) hasNextFlag = inner['hasNext'] as bool;
+        } else if (inner['content'] is List) {
+          rawList = inner['content'];
+          if (inner['last'] is bool) last = inner['last'] as bool;
+        }
+      }
+    }
+
+    final list = (rawList is List) ? rawList : const <dynamic>[];
+    final posts = list
+        .map<Post>((e) => Post.fromMap(Map<String, dynamic>.from(e)))
+        .toList();
+
+    bool hasNext;
+    if (hasNextFlag != null) {
+      hasNext = hasNextFlag;
+    } else if (last != null) {
+      hasNext = !last;
+    } else if (totalPages != null && number != null) {
+      hasNext = (number + 1) < totalPages;
+    } else {
+      // 정보가 없으면 "이번에 size만큼 왔으면 더 있을 것"으로 추정
+      hasNext = posts.length == size;
+    }
+
+    return PageResult(
+      items: posts,
+      hasNext: hasNext,
+      nextPage: hasNext ? page + 1 : null,
+    );
+  }
+
+  Future<Post> getOne(String id) async {
+    final res = await _dio.get('/posts/$id');
+    final data = (res.data is Map)
+        ? Map<String, dynamic>.from(res.data)
+        : <String, dynamic>{};
+    return Post.fromMap(data);
+  }
+}

--- a/lib/features/posts/presentation/post_detail_page.dart
+++ b/lib/features/posts/presentation/post_detail_page.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:route_pick_fe/features/state/posts_providers.dart';
+
+class PostDetailPage extends ConsumerWidget {
+  final String id;
+  const PostDetailPage({super.key, required this.id});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(postDetailProvider(id));
+    return Scaffold(
+      appBar: AppBar(title: Text('Post $id')),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('불러오기 실패: $e')),
+        data: (post) => Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(post.title, style: Theme.of(context).textTheme.titleLarge),
+              const SizedBox(height: 12),
+              if (post.summary != null) Text(post.summary!),
+              const SizedBox(height: 24),
+              const Text('(본문 / 메타데이터는 이후 단계에서 확장)'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/posts/presentation/posts_list_page.dart
+++ b/lib/features/posts/presentation/posts_list_page.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:route_pick_fe/features/state/posts_providers.dart';
+
+class PostsListPage extends ConsumerWidget {
+  const PostsListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(postsListControllerProvider);
+    final notifier = ref.read(postsListControllerProvider.notifier);
+
+    Widget buildBody() {
+      if (state.isLoading && state.items.isEmpty) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      if (state.error != null && state.items.isEmpty) {
+        return Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('불러오기 실패: ${state.error}'),
+                const SizedBox(height: 8),
+                FilledButton(
+                  onPressed: notifier.loadFirst,
+                  child: const Text('다시 시도'),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+      if (state.items.isEmpty) {
+        return const Center(child: Text('게시글이 없습니다.'));
+      }
+
+      // 스크롤 끝 근처에서 자동 더보기
+      return NotificationListener<ScrollNotification>(
+        onNotification: (n) {
+          if (n.metrics.pixels >= n.metrics.maxScrollExtent - 200) {
+            notifier.loadMore();
+          }
+          return false;
+        },
+        child: RefreshIndicator(
+          displacement: 56,
+          edgeOffset: 8,
+          onRefresh: () => notifier.loadFirst(),
+          child: ListView.separated(
+            physics: const AlwaysScrollableScrollPhysics(),
+            itemCount:
+                state.items.length +
+                ((state.isLoadingMore || state.hasMore) ? 1 : 0),
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (_, i) {
+              if (i < state.items.length) {
+                final p = state.items[i];
+                return ListTile(
+                  title: Text(p.title),
+                  subtitle: p.summary == null
+                      ? null
+                      : Text(
+                          p.summary!,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                  onTap: () => context.go('/posts/${p.id}'),
+                );
+              }
+              // footer
+              if (state.isLoadingMore) {
+                return const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 16),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+              // hasMore 이지만 아직 로딩 아닌 순간(트리거 전)엔 살짝 여백
+              if (state.hasMore) {
+                return const SizedBox(height: 56);
+              }
+              return const Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Center(child: Text('마지막 페이지입니다.')),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Posts')),
+      body: buildBody(),
+    );
+  }
+}

--- a/lib/features/state/posts_providers.dart
+++ b/lib/features/state/posts_providers.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:route_pick_fe/features/posts/data/post_model.dart';
+import 'package:route_pick_fe/features/posts/data/posts_api.dart';
+
+final postsApiProvider = Provider<PostsApi>((_) => PostsApi());
+
+class PostsState {
+  final List<Post> items;
+  final int page; // 다음 요청할 페이지 index
+  final bool isLoading; // 첫 로딩 or 새로고침 로딩
+  final bool isLoadingMore; // 더 불러오는 중
+  final bool hasMore; // 다음 페이지가 더 있는지
+  final Object? error;
+
+  const PostsState({
+    required this.items,
+    required this.page,
+    required this.isLoading,
+    required this.isLoadingMore,
+    required this.hasMore,
+    this.error,
+  });
+
+  factory PostsState.initial() => const PostsState(
+    items: [],
+    page: 0,
+    isLoading: true,
+    isLoadingMore: false,
+    hasMore: true,
+    error: null,
+  );
+
+  PostsState copyWith({
+    List<Post>? items,
+    int? page,
+    bool? isLoading,
+    bool? isLoadingMore,
+    bool? hasMore,
+    Object? error = _sentinel,
+  }) {
+    return PostsState(
+      items: items ?? this.items,
+      page: page ?? this.page,
+      isLoading: isLoading ?? this.isLoading,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      hasMore: hasMore ?? this.hasMore,
+      error: identical(error, _sentinel) ? this.error : error,
+    );
+  }
+
+  static const _sentinel = Object();
+}
+
+class PostsListController extends StateNotifier<PostsState> {
+  PostsListController(this._api) : super(PostsState.initial()) {
+    // 시작하자마자 첫 페이지 로드
+    loadFirst();
+  }
+
+  final PostsApi _api;
+  static const _pageSize = 20;
+  bool _busy = false;
+
+  Future<void> loadFirst() async {
+    if (_busy) return;
+    _busy = true;
+    state = state.copyWith(
+      isLoading: true,
+      error: null,
+      page: 0,
+      hasMore: true,
+    );
+    try {
+      final page = await _api.listPaged(page: 0, size: _pageSize);
+      state = state.copyWith(
+        items: page.items,
+        page: page.nextPage ?? 1,
+        hasMore: page.hasNext,
+        isLoading: false,
+        isLoadingMore: false,
+        error: null,
+      );
+    } catch (e, s) {
+      debugPrint('loadFirst error: $e\n$s');
+      state = state.copyWith(isLoading: false, error: e);
+    } finally {
+      _busy = false;
+    }
+  }
+
+  Future<void> loadMore() async {
+    if (_busy || state.isLoading || state.isLoadingMore || !state.hasMore) {
+      return;
+    }
+    _busy = true;
+    state = state.copyWith(isLoadingMore: true, error: null);
+    try {
+      final pageRes = await _api.listPaged(page: state.page, size: _pageSize);
+      state = state.copyWith(
+        items: [...state.items, ...pageRes.items],
+        page: pageRes.nextPage ?? state.page,
+        hasMore: pageRes.hasNext,
+        isLoadingMore: false,
+      );
+    } catch (e, s) {
+      debugPrint('loadMore error: $e\n$s');
+      // 더보기 실패는 목록 유지 + 토스트/스낵바로 처리(화면 쪽)
+      state = state.copyWith(isLoadingMore: false, error: e);
+    } finally {
+      _busy = false;
+    }
+  }
+}
+
+final postsListControllerProvider =
+    StateNotifierProvider.autoDispose<PostsListController, PostsState>((ref) {
+      final api = ref.read(postsApiProvider);
+      return PostsListController(api);
+    });
+
+// 상세는 그대로 family provider 유지 가능
+final postDetailProvider = FutureProvider.family.autoDispose<Post, String>((
+  ref,
+  id,
+) {
+  final api = ref.read(postsApiProvider);
+  return api.getOne(id);
+});


### PR DESCRIPTION
### 개요
 - 게시글 목록 무한 스크롤(바닥 근처 자동 더보기) + 당겨서 새로고침(Pull-to-Refresh) 적용
 - 게시글 상세 화면(!차) 추가 (제목/요약 중심, 본문 메타는 후속 단계에서 확장
 - API 클라이언트가 Spring Page 및 커스텀 목록 응답 (items/content/hasNext/last 등)을 모두 파싱하도록 범용화
 ---
### 변경 사항
- lib/features/posts/data/post_model.dart
  - 경량 Post 모델(id/title/summary)
- lib/features/posts/data/posts_api.dart
  - listPaged(page, size) → PageResult<Post>: hasNext/nextPage 계산 포함
  - getOne(id): 단건 조회
- lib/features/state/posts_providers.dart
  - PostsState: 항목/페이지/로딩/더보기/hasMore/에러 상태
  - PostsListController(StateNotifier): 첫 로딩, 더보기 로직
  - postsListsControllerProvider, postDetailProvider 정의
- lib/features/posts/presentation/posts_list_page.dart
  - NotificationListener<ScrollNotification>:하단 근처 도달 시 자동 더보기
  - RefreshIndicator: 당겨서 새로고침
  - 로딩/에러/빈 상태/푸터(로딩, 마지막 페이지) UI 처리
- lib/features/posts/presentation/post_detail_page.dart
  - 상세 화면(1차): 제목/요약 표시
---
### 동작 확인 방법
1. 목록 진입: /posts
   - 첫 페이지 로드 → 스크롤 하단 근처(끝에서 ~200px) 도달 시 자동으로 다음 페이지 로드
2. 새로고침: 위로 당겨서(모바일) 또는 터치/트랙패드 드래그로 Pull-to-Refresh → 첫 페이지부터 재로딩
3. 상세 이동: 목록 아이템 탭 → /posts/{id}로 이동, 제목/요약 확인