### PR TITLE
Feat/posts create

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -6,11 +6,12 @@ import 'package:route_pick_fe/features/auth/presentation/home_page.dart';
 import 'package:route_pick_fe/features/auth/presentation/login_page.dart';
 import 'package:route_pick_fe/features/auth/presentation/me_page.dart';
 import 'package:route_pick_fe/features/posts/presentation/post_detail_page.dart';
+import 'package:route_pick_fe/features/posts/presentation/post_write_page.dart';
 import 'package:route_pick_fe/features/posts/presentation/posts_list_page.dart';
 import 'package:route_pick_fe/features/splash/presentation/splash_page.dart';
 import 'package:route_pick_fe/features/state/auth_providers.dart';
 
-const _protectedPaths = {'/me', '/write'};
+const _protectedPaths = {'/me', '/posts/write'};
 
 final routerProvider = Provider<GoRouter>((ref) {
   final refresh = ValueNotifier(0);
@@ -44,9 +45,12 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/login', builder: (_, __) => const LoginPage()),
       GoRoute(path: '/me', builder: (_, __) => const MePage()),
       GoRoute(path: '/posts', builder: (_, __) => const PostsListPage()),
+      GoRoute(path: '/posts/write', builder: (_, __) => const PostWritePage()),
       GoRoute(
         path: '/posts/:id',
-        builder: (_, state) => PostDetailPage(id: state.pathParameters['id']!),
+        builder: (_, s) {
+          return PostDetailPage(id: s.pathParameters['id']!);
+        },
       ),
     ],
   );

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -14,33 +14,70 @@ import 'package:route_pick_fe/features/state/auth_providers.dart';
 const _protectedPaths = {'/me', '/posts/write'};
 
 final routerProvider = Provider<GoRouter>((ref) {
-  final refresh = ValueNotifier(0);
-  ref.listen<String?>(accessTokenProvider, (_, __) => refresh.value++);
-
-  String? token() => ref.read(accessTokenProvider);
-  bool authed() => (token() ?? '').isNotEmpty;
+  final notifier = ref.watch(routerNotifierProvider);
 
   return GoRouter(
     initialLocation: '/splash',
-    refreshListenable: refresh,
+    refreshListenable: notifier,
     debugLogDiagnostics: kDebugMode,
     redirect: (context, state) {
       final path = state.matchedLocation;
+      final uri = state.uri;
+      final fullLocation = uri.toString();
+      final authed = (notifier.token ?? '').isNotEmpty;
 
-      // 보호 경로만 가드
-      if (!authed() && _protectedPaths.any((p) => path.startsWith(p))) {
-        final going = state.uri.toString();
-        return '/login?from=${Uri.encodeComponent(going)}';
+      if (!notifier.bootstrapped) {
+        if (path == '/splash') return null;
+        return Uri(
+          path: '/splash',
+          queryParameters: {'from': fullLocation},
+        ).toString();
       }
-      // 로그인된 상태에서 /login로 못 가게
-      if (authed() && path == '/login') {
-        final from = state.uri.queryParameters['from'];
-        return from ?? '/';
+
+      if (path == '/splash') {
+        final fromParam = uri.queryParameters['from'];
+        if (!authed) {
+          if (fromParam == null || fromParam.isEmpty) return '/';
+          final fromUri = Uri.tryParse(fromParam);
+          final fromPath = fromUri?.path ?? fromParam;
+          final needsLogin =
+              _protectedPaths.any((protected) => fromPath.startsWith(protected));
+          if (needsLogin) {
+            return Uri(
+              path: '/login',
+              queryParameters: {'from': fromParam},
+            ).toString();
+          }
+          return fromParam;
+        }
+        return fromParam ?? '/';
       }
+
+      if (!authed) {
+        if (path == '/login') return null;
+        final protected =
+            _protectedPaths.any((protected) => path.startsWith(protected));
+        if (!protected) return null;
+        return Uri(
+          path: '/login',
+          queryParameters: {'from': fullLocation},
+        ).toString();
+      }
+
+      if (path == '/login') {
+        final fromParam = uri.queryParameters['from'];
+        return fromParam ?? '/';
+      }
+
       return null;
     },
     routes: [
-      GoRoute(path: '/splash', builder: (_, __) => const SplashPage()),
+      GoRoute(
+        path: '/splash',
+        builder: (_, state) => SplashPage(
+          initialTarget: state.uri.queryParameters['from'],
+        ),
+      ),
       GoRoute(path: '/', builder: (_, __) => const HomePage()),
       GoRoute(path: '/login', builder: (_, __) => const LoginPage()),
       GoRoute(path: '/me', builder: (_, __) => const MePage()),

--- a/lib/features/posts/data/posts_api.dart
+++ b/lib/features/posts/data/posts_api.dart
@@ -90,4 +90,36 @@ class PostsApi {
         : <String, dynamic>{};
     return Post.fromMap(data);
   }
+
+  Future<String> create({
+    required String title,
+    required String content,
+    String? region,
+    List<String>? tags,
+    double? latitude,
+    double? longitude,
+    required String accessToken,
+  }) async {
+    final res = await _dio.post(
+      '/posts',
+      data: {
+        'title': title,
+        'content': content,
+        if (region != null && region.isNotEmpty) 'region': region,
+        if (tags != null) 'tags': tags,
+        if (latitude != null && longitude != null) ...{
+          'latitude': latitude,
+          'longitude': longitude,
+        },
+      },
+      options: Options(headers: {'Authorization': 'Bearer $accessToken'}),
+    );
+
+    final data = res.data;
+    if (data is Map && data['id'] != null) return '${data['id']}';
+    if (data is Map && data['data'] is Map && data['data']['id'] != null) {
+      return '${data['data']['id']}';
+    }
+    return '$data';
+  }
 }

--- a/lib/features/posts/presentation/post_write_page.dart
+++ b/lib/features/posts/presentation/post_write_page.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:route_pick_fe/features/state/posts_providers.dart';
+
+class PostWritePage extends ConsumerStatefulWidget {
+  const PostWritePage({super.key});
+  @override
+  ConsumerState<PostWritePage> createState() => _PostWritePageState();
+}
+
+class _PostWritePageState extends ConsumerState<PostWritePage> {
+  final _formKey = GlobalKey<FormState>();
+  final _title = TextEditingController();
+  final _content = TextEditingController();
+  final _region = TextEditingController();
+  final _tags = TextEditingController(); // "태그1, 태그2"
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _content.dispose();
+    _region.dispose();
+    _tags.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final state = ref.read(postCreateControllerProvider);
+    final notifier = ref.read(postCreateControllerProvider.notifier);
+
+    if (state.submitting) return;
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    final tags = _tags.text
+        .split(',')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toList();
+
+    final id = await notifier.submit(
+      title: _title.text.trim(),
+      content: _content.text.trim(),
+      region: _region.text.trim().isEmpty ? null : _region.text.trim(),
+      tags: tags.isEmpty ? null : tags,
+    );
+
+    if (!mounted) return;
+
+    if (id != null) {
+      context.go('/posts/$id');
+    } else {
+      final err = ref.read(postCreateControllerProvider).error;
+      if (err != null) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('작성 실패: $err')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(postCreateControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('새 글 작성'),
+        actions: [
+          TextButton(
+            onPressed: state.submitting ? null : _submit, // <-- 이렇게 호출
+            child: state.submitting
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('저장'),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _title,
+                decoration: const InputDecoration(labelText: '제목'),
+                maxLength: 120,
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? '제목을 입력하세요' : null,
+                enabled: !state.submitting,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _content,
+                decoration: const InputDecoration(labelText: '내용'),
+                maxLines: 8,
+                maxLength: 4000,
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? '내용을 입력하세요' : null,
+                enabled: !state.submitting,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _region,
+                decoration: const InputDecoration(labelText: '지역(선택)'),
+                enabled: !state.submitting,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _tags,
+                decoration: const InputDecoration(labelText: '태그(쉼표로 구분, 선택)'),
+                enabled: !state.submitting,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/splash/presentation/splash_page.dart
+++ b/lib/features/splash/presentation/splash_page.dart
@@ -7,7 +7,9 @@ import 'package:route_pick_fe/features/auth/data/auth_api.dart';
 import 'package:route_pick_fe/features/state/auth_providers.dart';
 
 class SplashPage extends ConsumerStatefulWidget {
-  const SplashPage({super.key});
+  const SplashPage({super.key, this.initialTarget});
+
+  final String? initialTarget;
   @override
   ConsumerState<SplashPage> createState() => _SplashPageState();
 }
@@ -29,12 +31,34 @@ class _SplashPageState extends ConsumerState<SplashPage> {
 
     debugPrint('[Splash] boot start');
 
+    final fromParam = widget.initialTarget;
+    String? normalizeTarget(String? value) {
+      if (value == null || value.isEmpty || value == '/splash') return null;
+      return value;
+    }
+    final target = normalizeTarget(fromParam);
+    bool needsLogin(String? location) {
+      if (location == null) return false;
+      final uri = Uri.tryParse(location);
+      final path = uri?.path ?? location;
+      return path.startsWith('/me') || path.startsWith('/posts/write');
+    }
+    final requiresLogin = needsLogin(target);
+    final loginUri = Uri(
+      path: '/login',
+      queryParameters: target == null ? null : {'from': target},
+    ).toString();
+
     try {
       // 1) 디스크에서 토큰 로드
       final saved = await ref.read(tokenStorageProvider).load();
       debugPrint('[Splash] saved token? ${saved != null}');
       if (saved == null || saved.isEmpty) {
-        _safeGo('/login');
+        if (requiresLogin) {
+          _safeGo(loginUri);
+        } else {
+          _safeGo(target ?? '/');
+        }
         return;
       }
 
@@ -44,7 +68,7 @@ class _SplashPageState extends ConsumerState<SplashPage> {
       // 3) 서버로 토큰 확인 (me 호출)
       await _api.me(accessToken: saved);
       debugPrint('[Splash] me OK → /');
-      _safeGo('/'); // OK이면 홈
+      _safeGo(target ?? '/'); // OK이면 원래 가려던 곳 또는 홈
     } on DioException catch (e) {
       debugPrint(
         '[Splash] DioException status=${e.response?.statusCode} type=${e.type}',
@@ -52,13 +76,13 @@ class _SplashPageState extends ConsumerState<SplashPage> {
       // 401 등 → 토큰 삭제 후 로그인
       ref.read(accessTokenProvider.notifier).state = null;
       await ref.read(tokenStorageProvider).save(null);
-      _safeGo('/login');
+      _safeGo(requiresLogin ? loginUri : (target ?? '/'));
     } catch (e) {
       debugPrint('[Splash] unknown error: $e');
       // 알 수 없는 오류 → 안전하게 로그인으로
       ref.read(accessTokenProvider.notifier).state = null;
       await ref.read(tokenStorageProvider).save(null);
-      _safeGo('/login');
+      _safeGo(requiresLogin ? loginUri : (target ?? '/'));
     }
   }
 

--- a/lib/features/state/auth_providers.dart
+++ b/lib/features/state/auth_providers.dart
@@ -38,20 +38,6 @@ class RouterNotifier extends ChangeNotifier {
 
   String? get token => ref.read(accessTokenProvider);
   bool get bootstrapped => ref.read(authBootstrapProvider).hasValue;
-
-  String? redirectLogic(_, state) {
-    final path = state.matchedLocation; // go_router 버전에 따라 state.subloc일 수 있음
-    final going = state.uri.toString();
-
-    if (!bootstrapped) return path == '/splash' ? null : '/splash';
-    if (token == null) {
-      return path == '/login'
-          ? null
-          : '/login?from=${Uri.encodeComponent(going)}';
-    }
-    if (path == '/login') return '/';
-    return null;
-  }
 }
 
 final routerNotifierProvider = Provider<RouterNotifier>(

--- a/lib/features/state/posts_providers.dart
+++ b/lib/features/state/posts_providers.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:route_pick_fe/features/posts/data/post_model.dart';
 import 'package:route_pick_fe/features/posts/data/posts_api.dart';
+import 'package:route_pick_fe/features/state/auth_providers.dart';
 
 final postsApiProvider = Provider<PostsApi>((_) => PostsApi());
 
@@ -128,3 +129,59 @@ final postDetailProvider = FutureProvider.family.autoDispose<Post, String>((
   final api = ref.read(postsApiProvider);
   return api.getOne(id);
 });
+
+class PostCreateState {
+  final bool submitting;
+  final Object? error;
+  const PostCreateState({required this.submitting, this.error});
+  factory PostCreateState.initial() => const PostCreateState(submitting: false);
+  PostCreateState copyWith({bool? submitting, Object? error}) =>
+      PostCreateState(submitting: submitting ?? this.submitting, error: error);
+}
+
+class PostCreateController extends StateNotifier<PostCreateState> {
+  PostCreateController(this._api, this._ref) : super(PostCreateState.initial());
+  final PostsApi _api;
+  final Ref _ref;
+
+  Future<String?> submit({
+    required String title,
+    required String content,
+    String? region,
+    List<String>? tags,
+    double? latitude,
+    double? longitude,
+  }) async {
+    if (state.submitting) return null;
+
+    final token = _ref.read(accessTokenProvider);
+    if (token == null || token.isEmpty) {
+      state = state.copyWith(submitting: false, error: '로그인이 필요합니다');
+      return null;
+    }
+
+    state = state.copyWith(submitting: true, error: null);
+    try {
+      final id = await _api.create(
+        title: title,
+        content: content,
+        region: region,
+        tags: tags,
+        latitude: latitude,
+        longitude: longitude,
+        accessToken: token, // ✅ 토큰 전달
+      );
+      state = state.copyWith(submitting: false, error: null);
+      return id;
+    } catch (e) {
+      state = state.copyWith(submitting: false, error: e);
+      return null;
+    }
+  }
+}
+
+// 프로바이더 등록
+final postCreateControllerProvider =
+    StateNotifierProvider.autoDispose<PostCreateController, PostCreateState>(
+      (ref) => PostCreateController(ref.read(postsApiProvider), ref),
+    );


### PR DESCRIPTION
### 개요
 - 게시글 작성 화면을 추가하고, 제출 상태 관리(Riverpod StateNotifier) 및 생성 API를 연동
 - /posts/write는 로그인 필요 경로로 가드 처리되었습니다. 생성 성공 시 새 글 상세로 이동

###변경사항
- features/posts/presentation/post_write_page.dart
  - 제목/내용 필수 검증, 지역/태그(쉼표 구분) 입력, 제출 중 버튼 로딩 표시
  - 성공 시 context.go('/posts/{id}'), 실패 시 스낵바
- features/state/posts_providers.dart
  - PostCreateState, PostCreateController, postCreateControllerProvider 추가
  - accessTokenProvider에서 토큰 읽어 Bearer 헤더로 전달
- features/posts/data/posts_api.dart
  - create() 추가: Authorization: Bearer <token>으로 POST /posts
  - 응답에서 생성 ID 파싱({ id } 또는 { data: { id } } 대응)
- router.dart
  - 라우트 '/posts/write' 추가
  - 보호 경로 집합에 '/posts/write' 포함(비로그인 시 /login?from=... 리다이렉트)